### PR TITLE
Make-Interactable-button-doesnt-check-if-the-object-does-not-have-a-Renderer-component_CU-ev5axk

### DIFF
--- a/Snowy-Path/Assets/Scripts/Editor/CreationMenus/AmmunitionCreationMenu.cs
+++ b/Snowy-Path/Assets/Scripts/Editor/CreationMenus/AmmunitionCreationMenu.cs
@@ -26,6 +26,9 @@ public class AmmunitionCreationMenu : MonoBehaviour
         // Scene utility
         GameObjectUtility.SetParentAndAlign(go, menuCommand.context as GameObject);
 
+        // Last child of parent / Bottom of hierarchy
+        go.transform.SetAsLastSibling();
+
         Undo.RegisterCreatedObjectUndo(go, "Create " + go.name);
         Selection.activeObject = go;
 
@@ -47,6 +50,9 @@ public class AmmunitionCreationMenu : MonoBehaviour
 
         // Scene utility
         GameObjectUtility.SetParentAndAlign(go, menuCommand.context as GameObject);
+
+        // Last child of parent / Bottom of hierarchy
+        go.transform.SetAsLastSibling();
 
         Undo.RegisterCreatedObjectUndo(go, "Create " + go.name);
         Selection.activeObject = go;

--- a/Snowy-Path/Assets/Scripts/Editor/CreationMenus/CampfireCreationMenu.cs
+++ b/Snowy-Path/Assets/Scripts/Editor/CreationMenus/CampfireCreationMenu.cs
@@ -25,6 +25,9 @@ public class CampfireCreationMenu {
         // Scene utility
         GameObjectUtility.SetParentAndAlign(go, menuCommand.context as GameObject);
 
+        // Last child of parent / Bottom of hierarchy
+        go.transform.SetAsLastSibling();
+
         Undo.RegisterCreatedObjectUndo(go, "Create " + go.name);
         Selection.activeObject = go;
 

--- a/Snowy-Path/Assets/Scripts/Editor/CreationMenus/ClothCreationMenu.cs
+++ b/Snowy-Path/Assets/Scripts/Editor/CreationMenus/ClothCreationMenu.cs
@@ -26,6 +26,9 @@ public class ClothCreationMenu {
         // Scene utility
         GameObjectUtility.SetParentAndAlign(go, menuCommand.context as GameObject);
 
+        // Last child of parent / Bottom of hierarchy
+        go.transform.SetAsLastSibling();
+
         Undo.RegisterCreatedObjectUndo(go, "Create " + go.name);
         Selection.activeObject = go;
 
@@ -48,6 +51,9 @@ public class ClothCreationMenu {
         // Scene utility
         GameObjectUtility.SetParentAndAlign(go, menuCommand.context as GameObject);
 
+        // Last child of parent / Bottom of hierarchy
+        go.transform.SetAsLastSibling();
+
         Undo.RegisterCreatedObjectUndo(go, "Create " + go.name);
         Selection.activeObject = go;
 
@@ -69,6 +75,9 @@ public class ClothCreationMenu {
 
         // Scene utility
         GameObjectUtility.SetParentAndAlign(go, menuCommand.context as GameObject);
+
+        // Last child of parent / Bottom of hierarchy
+        go.transform.SetAsLastSibling();
 
         Undo.RegisterCreatedObjectUndo(go, "Create " + go.name);
         Selection.activeObject = go;

--- a/Snowy-Path/Assets/Scripts/Editor/CreationMenus/InteractableCreationMenu.cs
+++ b/Snowy-Path/Assets/Scripts/Editor/CreationMenus/InteractableCreationMenu.cs
@@ -42,9 +42,13 @@ public class InteractableCreationMenu {
     /// It adds the Interactable script and the OutlineEffect material in first position while conserving other materials.
     /// </summary>
     /// <param name="go">The modified gameobject.</param>
-    private static void MakeGameObjectInteractable(GameObject go) {
+    internal static void MakeGameObjectInteractable(GameObject go) {
 
-        Renderer rend = go.GetComponent<Renderer>();
+        GetOrAddMeshFilterComponent(go);
+
+        // Get a Renderer component
+        // OR Add a MeshRenderer component
+        Renderer rend = GetOrAddMeshRendererComponent(go);
 
         // Outline shader
         Material[] oldMaterials = rend.sharedMaterials;
@@ -80,20 +84,8 @@ public class InteractableCreationMenu {
         // Position
         MenuUtility.PlaceInFrontOfCamera(go);
 
-        // Renderer
-        MeshRenderer renderer = go.AddComponent<MeshRenderer>();
-
-        // Outline shader
-        renderer.material = RetrieveOutlineEffectMaterial(); //To place the outline shader at the first place FOREVER
-
-        // Mesh filter
-        go.AddComponent<MeshFilter>();
-
-        // Mesh Collider
-        go.AddComponent<MeshCollider>();
-
-        // Interactable
-        AddInteractableScript(go);
+        // Add needed component
+        MakeGameObjectInteractable(go);
 
         // Scene utility
         GameObjectUtility.SetParentAndAlign(go, menuCommand.context as GameObject);
@@ -116,7 +108,7 @@ public class InteractableCreationMenu {
         go.name = "CubeInteractable";
 
         // Complete go with needed scripts
-        CompletePrimitive(go);
+        CompletePrimitiveWithInteractable(go);
 
         // Scene utility
         GameObjectUtility.SetParentAndAlign(go, menuCommand.context as GameObject);
@@ -139,7 +131,7 @@ public class InteractableCreationMenu {
         go.name = "SphereInteractable";
 
         // Complete go with needed scripts
-        CompletePrimitive(go);
+        CompletePrimitiveWithInteractable(go);
 
         // Scene utility
         GameObjectUtility.SetParentAndAlign(go, menuCommand.context as GameObject);
@@ -162,7 +154,7 @@ public class InteractableCreationMenu {
         go.name = "CapsuleInteractable";
 
         // Complete go with needed scripts
-        CompletePrimitive(go);
+        CompletePrimitiveWithInteractable(go);
 
         // Scene utility
         GameObjectUtility.SetParentAndAlign(go, menuCommand.context as GameObject);
@@ -185,7 +177,7 @@ public class InteractableCreationMenu {
         go.name = "CylinderInteractable";
 
         // Complete go with needed scripts
-        CompletePrimitive(go);
+        CompletePrimitiveWithInteractable(go);
 
         // Scene utility
         GameObjectUtility.SetParentAndAlign(go, menuCommand.context as GameObject);
@@ -208,7 +200,7 @@ public class InteractableCreationMenu {
         go.name = "PlaneInteractable";
 
         // Complete go with needed scripts
-        CompletePrimitive(go);
+        CompletePrimitiveWithInteractable(go);
 
         // Scene utility
         GameObjectUtility.SetParentAndAlign(go, menuCommand.context as GameObject);
@@ -223,7 +215,6 @@ public class InteractableCreationMenu {
     #region Interactable Utility
 
     private static Material RetrieveOutlineEffectMaterial() {
-        //return (Material)Resources.Load("Materials/OutlineEffect", typeof(Material));
         return (Material)AssetDatabase.LoadAssetAtPath("Assets/Materials/OutlineEffect.mat", typeof(Material));
     }
 
@@ -233,7 +224,7 @@ public class InteractableCreationMenu {
     /// And adds the OutlineEffect material in first position.
     /// </summary>
     /// <param name="go">The modified gameobject.</param>
-    private static void CompletePrimitive(GameObject go) {
+    private static void CompletePrimitiveWithInteractable(GameObject go) {
 
         // Position
         MenuUtility.PlaceInFrontOfCamera(go);
@@ -252,15 +243,68 @@ public class InteractableCreationMenu {
 
     }
 
+    /// <summary>
+    /// Get the current MeshFilter component. If there is no such component, add one.
+    /// </summary>
+    /// <param name="go">The modified gameobject.</param>
+    /// <returns>Current or new MeshFilter.</returns>
+    private static MeshFilter GetOrAddMeshFilterComponent(GameObject go) {
+        MeshFilter coll = go.GetComponent<MeshFilter>();
+        if (coll != null) {
+            return coll;
+        }
+        return Undo.AddComponent<MeshFilter>(go);
+    }
+
+    /// <summary>
+    /// Get the current Renderer component. If there is no such component, add one MeshRenderer.
+    /// </summary>
+    /// <param name="go">The modified gameobject.</param>
+    /// <returns>Current or new Renderer.</returns>
+    private static Renderer GetOrAddMeshRendererComponent(GameObject go) {
+        Renderer rend = go.GetComponent<Renderer>();
+        if (rend != null) {
+            return rend;
+        }
+        return Undo.AddComponent<MeshRenderer>(go);
+    }
+
+    /// <summary>
+    /// Get the current Collider component. If there is no such component, add one MeshCollider.
+    /// </summary>
+    /// <param name="go">The modified gameobject.</param>
+    /// <returns>Current or new Collider.</returns>
+    private static Collider GetOrAddMeshColliderComponent(GameObject go) {
+        Collider coll = go.GetComponent<Collider>();
+        if (coll != null) {
+            return coll;
+        }
+        return Undo.AddComponent<MeshCollider>(go);
+    }
+
+    /// <summary>
+    /// Get the current Interactable component. If there is no such component, add one.
+    /// </summary>
+    /// <param name="go">The modified gameobject.</param>
+    /// <returns>Current or new Interactable.</returns>
+    private static Interactable GetOrAddInteractableComponent(GameObject go) {
+        Interactable interac = go.GetComponent<Interactable>();
+        if (interac != null) {
+            return interac;
+        }
+        return Undo.AddComponent<Interactable>(go);
+    }
 
     /// <summary>
     /// Add the Interactable script and bind feedbacks to corresponding method.
     /// </summary>
     /// <param name="go">The modified gameobject.</param>
     private static void AddInteractableScript(GameObject go) {
+
+        GetOrAddMeshColliderComponent(go);
+
         // Interactable script
-        //Interactable interac = (Interactable)Undo.AddComponent(go, typeof(Interactable));
-        Interactable interac = (Interactable)Undo.AddComponent(go, typeof(Interactable));
+        Interactable interac = GetOrAddInteractableComponent(go);
 
         // Show Interaction Feedback
         interac.onShowFeedback = new UnityEvent();

--- a/Snowy-Path/Assets/Scripts/Editor/CreationMenus/PowderCreationMenus.cs
+++ b/Snowy-Path/Assets/Scripts/Editor/CreationMenus/PowderCreationMenus.cs
@@ -13,7 +13,7 @@ public class PowderCreationMenu {
     /// Instantiate a Powder Prefab with the Interactable script.
     /// </summary>
     /// <param name="menuCommand"></param>
-    [MenuItem("GameObject/Powders/Powder", false, 10)]
+    [MenuItem("GameObject/Powder", false, 10)]
     public static void CreatePowder(MenuCommand menuCommand) {
 
         // LightCloth prefab
@@ -24,6 +24,9 @@ public class PowderCreationMenu {
 
         // Scene utility
         GameObjectUtility.SetParentAndAlign(go, menuCommand.context as GameObject);
+
+        // Last child of parent / Bottom of hierarchy
+        go.transform.SetAsLastSibling();
 
         Undo.RegisterCreatedObjectUndo(go, "Create " + go.name);
         Selection.activeObject = go;


### PR DESCRIPTION
Added more checking when making a gameobject an Interactable one for components :
- MeshFilter
- Collider
- Renderer
- Interactable.
If they do not exist, they are added to the gameobject.

Plus, prefabs such as Powder and Campfire are now positionned at the end of the hierarchy list or the end of the children list of any gameobject.